### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/lib/libfacedetection/version.rb
+++ b/lib/libfacedetection/version.rb
@@ -1,3 +1,3 @@
 module Libfacedetection
-  VERSION = "0.2.8".freeze
+  VERSION = "0.3.0".freeze
 end


### PR DESCRIPTION
Bump the version to 0.3.0. After [this one is merged](https://github.com/fetlife/facedetection-ruby/pull/18) we can release a new version.