### PR TITLE
Fix release workflow: build native gems with rb-sys-dock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,113 +3,76 @@ on:
   push:
     tags:
       - "[0-9]*.[0-9]*.[0-9]*"
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
-  build_gem:
+  build_source_gem:
     name: Build source gem
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby-pkgs@v1
+      - uses: actions/checkout@v6.0.2
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
-      - run: sudo apt-get update && sudo apt-get install -y libopencv-dev libvips
-      - run: gem update --system
-      - run: rake gem
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec rake build
       - name: Upload source gem
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
-          name: libfacedetection.gem
+          name: source-gem
           path: pkg/*.gem
           retention-days: 1
 
-  compile_native_gems:
-    name: Compile native gem
-    needs: build_gem
+  build_native_gems:
+    name: Build native gem (${{ matrix.platform }})
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-24.04
-            platform: x86_64-linux
-            ruby: "3.4"
-          - os: ubuntu-24.04-arm
-            platform: aarch64-linux
-            ruby: "3.4"
-          - os: macos-latest
-            platform: arm64-darwin
-            ruby: "3.4"
-    runs-on: ${{ matrix.os }}
+        platform:
+          - x86_64-linux
+          - aarch64-linux
+          - x86_64-darwin
+          - arm64-darwin
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: ruby/setup-ruby-pkgs@v1
+      - uses: actions/checkout@v6.0.2
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-
-      - name: Install system dependencies on Linux
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-latest-arm64'
-        run: sudo apt-get update && sudo apt-get install -y libopencv-dev libvips
-
-      - name: Install system dependencies on macOS
-        if: matrix.os == 'macos-latest'
-        run: brew install opencv vips
-
-      - name: Install gem-compiler
-        run: gem install gem-compiler
-
-      - name: Download source gem
-        uses: actions/download-artifact@v4
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Build native gems
+        run: bundle exec rb-sys-dock --platform ${{ matrix.platform }} --build
+      - name: Upload native gems
+        uses: actions/upload-artifact@v7.0.0
         with:
-          name: libfacedetection.gem
-          path: pkg/
-
-      - name: Compile gem
-        run: |
-          SOURCE_GEM=$(ls pkg/*.gem | grep -v -- '-x86_64-linux\|aarch64-linux\|arm64-darwin')
-          gem compile $SOURCE_GEM --prune
-
-      - name: Upload compiled gem
-        uses: actions/upload-artifact@v4
-        with:
-          name: libfacedetection-${{ matrix.platform }}.gem
-          path: ./*.gem
+          name: native-gem-${{ matrix.platform }}
+          path: pkg/*-${{ matrix.platform }}.gem
           retention-days: 1
 
   release:
     name: Create GitHub Release
-    needs: compile_native_gems
+    needs:
+      - build_source_gem
+      - build_native_gems
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-
       - name: Extract version
-        id: extract_version
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
           echo "GEM_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
-
-      - name: Rename gem files with version
-        run: |
-          mkdir -p release_gems
-          for gem in artifacts/libfacedetection-*.gem/*.gem; do
-            platform=$(basename $gem | sed -E 's/libfacedetection-([^-]+-[^-]+)\.gem/\1/')
-
-            # Construct the target filename: NAME-VERSION-PLATFORM.gem
-            target_filename="libfacedetection-${GEM_VERSION}-${platform}.gem"
-            target_path="release_gems/$target_filename"
-            mv "$gem" "$target_path"
-          done
-          # Move source gem to release_gems directory
-          mv artifacts/libfacedetection.gem/*.gem release_gems/libfacedetection-${GEM_VERSION}.gem
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.GEM_VERSION }}
-          files: release_gems/*.gem
+          tag_name: ${{ github.ref_name }}
+          name: libfacedetection ${{ env.GEM_VERSION }}
+          files: artifacts/**/*.gem
           generate_release_notes: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,29 +1,17 @@
-require 'rubygems/package_task'
+# frozen_string_literal: true
 
-spec = eval(File.read("libfacedetection.gemspec"))
-GEM_RUBY_VERSION = "3.4.0"
-DOCKER_IMAGE = "ruby:#{GEM_RUBY_VERSION}-bullseye"
+require "bundler/gem_tasks"
 
-def compile_cmd(_arch)
-  "gem instal gem-compiler; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; source '/root/.cargo/env'; rake gem:native"
-end
+task gem: :build
 
-gem_task = Gem::PackageTask.new(spec) do |pkg|
-  pkg.need_zip = true
-  pkg.need_tar = true
-end
+begin
+  require "rb_sys/extensiontask"
 
-desc "Generate a pre-compiled native gem for #{RUBY_PLATFORM}"
-task "gem:native" => ["gem"] do
-  sh "gem compile #{gem_task.package_dir_path}.gem"
-end
+  GEMSPEC = Gem::Specification.load("libfacedetection.gemspec")
 
-desc "Generate a pre-compiled native gem for aarch64-linux"
-task "gem:native:aarch64-linux" => ["gem"] do
-  sh %{docker run --rm --platform linux/arm64 -v $(pwd):/src -w /src #{DOCKER_IMAGE} /bin/bash -c "#{compile_cmd('aarch64-unknown-linux-musl')}"}
-end
-
-desc "Generate a pre-compiled native gem for x86_64-linux"
-task "gem:native:x86_64-linux" => ["gem"] do
-  sh %{docker run --rm --platform linux/amd64 -v $(pwd):/src -w /src #{DOCKER_IMAGE} /bin/bash -c "#{compile_cmd('x86_64-unknown-linux-musl')}"}
+  RbSys::ExtensionTask.new("libfacedetection-ruby", GEMSPEC) do |ext|
+    ext.lib_dir = "lib/libfacedetection"
+  end
+rescue LoadError
+  warn "rb_sys not available, skipping compile tasks (run `bundle install` to enable them)"
 end

--- a/lib/libfacedetection/version.rb
+++ b/lib/libfacedetection/version.rb
@@ -1,3 +1,3 @@
 module Libfacedetection
-  VERSION = "0.4.0".freeze
+  VERSION = "0.4.1".freeze
 end


### PR DESCRIPTION
The 0.4.0 release failed: since #22 the extension is built with `rb_sys/mkmf`, but the release workflow still compiled native gems with `gem-compiler`, which runs `extconf.rb` without the gem's dependencies installed:

    cannot load such file -- rb_sys/mkmf (LoadError)

This replaces the gem-compiler flow with the standard rb-sys toolchain, the same setup used in fetlife/distributing-iterator#8:

- Rakefile: `bundler/gem_tasks` + `RbSys::ExtensionTask` (rake-compiler) replace the old `Gem::PackageTask` / `gem compile` tasks; `rake gem` keeps working as an alias for `rake build`.
- Release workflow: builds the source gem with `rake build` and cross-compiles native gems with `rb-sys-dock` for x86_64-linux, aarch64-linux, x86_64-darwin and arm64-darwin (one more platform than before), all on ubuntu runners. Artifacts are attached to the GitHub release.
- Native gems now bundle binaries for each supported Ruby ABI (3.0–4.0), matching the per-ABI loader added in #22 — Ruby 4.0 gets precompiled binaries too.
- Bumps the version to 0.4.1 so a fresh tag can be cut (the 0.4.0 tag points at the failed release).

Windows is not included because the vendored libfacedetection bindings currently cover only the four platforms above; other platforms fall back to the source gem, which compiles locally.

### Testing

- `bundle exec rake build` / `bundle exec rake gem` produce the source gem
- Installed the source gem locally (compiles via `rb_sys/mkmf`) and ran `tests/test_detection.rb` — passes
- `bundle exec rb-sys-dock --platform <p> --build` run locally for aarch64-linux, arm64-darwin and x86_64-darwin — each produces a native gem bundling `lib/libfacedetection/{3.0…4.0}/libfacedetection_ruby.{so,bundle}`
- Installed the aarch64-linux native gem in clean `ruby:3.4` and `ruby:4.0` containers — installs without compiling and loads
- Installed the arm64-darwin native gem natively on an Apple Silicon Mac — `tests/test_detection.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
